### PR TITLE
💄 styles : flex to grid layout change

### DIFF
--- a/component/Camp.jsx
+++ b/component/Camp.jsx
@@ -39,6 +39,7 @@ const CampContainer = styled.div`
   border-radius: ${({ borderRadius }) => `${borderRadius}px`};
   box-sizing: content-box;
   margin: 10px;
+  justify-self: center;
 `;
 
 const PictureContainer = styled.div``;

--- a/component/CampContainer.jsx
+++ b/component/CampContainer.jsx
@@ -9,24 +9,26 @@ import {
   getImageList,
 } from "../core/api/axios";
 
-const CampContainer = () => {
+const CampContainer = ({ containerWidth = 223, containerHeight = 300 }) => {
   const [data, setData] = useState([]);
   useEffect(() => {
     // Todo : 상황에 따라 API 사용 예정
     async function api() {
-      const data = await getSearchList(1);
+      const data = await getLocationBasedList(1);
       setData(data);
     }
     api();
   }, []);
   return (
-    <Container>
+    <Container containerWidth={containerWidth}>
       {data.map(({ facltNm, addr1, firstImageUrl }) => (
         <Camp
           className="camp"
           title={facltNm}
           address={addr1}
           imgSrc={firstImageUrl}
+          containerWidth={containerWidth}
+          containerHeight={containerHeight}
         ></Camp>
       ))}
     </Container>
@@ -35,12 +37,14 @@ const CampContainer = () => {
 
 // 상위 태그의 크기에 영향을 받는다.
 const Container = styled.div`
-  display: flex;
   width: 100%;
   height: auto;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(${({ containerWidth }) => `${containerWidth}px`}, 1fr)
+  );
+  grid-gap: 20px;
 `;
 
 export default CampContainer;


### PR DESCRIPTION
# 기존의 flex의 문제점
Camp 컴포넌트 여러개를 2차원 형태로 정렬하려하니
중앙정렬을 할 경우 (justify-content:center) 4x3 행렬 상태에서
10개의 Camp 컴포넌트에 대한 마지막 컴포넌트가 왼쪽 끝이 아닌 중앙에 위치하여
의도하지않은 레이아웃이 발생하여 중앙정렬을 취소하니
전반적인 레이아웃이 왼쪽으로 치우친 상태가 발생

# 해결책
예전 팀프로젝트 내용을 보면서 Grid로 레이아웃을 잡으면 각각마다 중앙정렬이 가능해지고
마지막 부분에 대해서는 왼쪽에서부터 차례로 나타나는 형태로 변경 

```css
display: grid;
  grid-template-columns: repeat(
    auto-fit,
    minmax(${({ containerWidth }) => `${containerWidth}px`}, 1fr)
  );
  grid-gap: 20px;
```
>이때의 containerWidth는 하나의 컴포넌트(item)이다. 
설정된 너비가 허용하는 한 최대한 셀을 채우게 repeat내에 auto-fit을 지정하고 
minmax를 통해 하나의 컴포넌트가 최소한 가지는 영역을 설정한다. (1fr을 통해 넓어질수있을만큼 넓어지고 containerWidth를 통해 최소 해당 px만큼만 줄어들게 처리)
 