### PR TITLE
🐛 fix : react selected error 해결

### DIFF
--- a/component/SelectBox.jsx
+++ b/component/SelectBox.jsx
@@ -7,12 +7,14 @@ const SelectBox = ({
   changeSelectBoxOption,
 }) => {
   return (
-    <select name="job" onChange={changeSelectBoxOption}>
-      <option value={optionsTitle} disabled selected>
+    <select onChange={changeSelectBoxOption} value={optionsTitle}>
+      <option value={optionsTitle} disabled>
         {optionsTitle}
       </option>
       {options.map((option) => (
-        <option value={option}>{option}</option>
+        <option value={option} key={option}>
+          {option}
+        </option>
       ))}
     </select>
   );


### PR DESCRIPTION
# 에러 내용
`Warning: Use the 'defaultValue' or 'value' props on <select> instead of setting 'selected' on <option>`
# 해결 방법
select에 value를 두고
해당 value를 default로 설정할 value와 연결짓고 동작하게 하지않기위해 disabled 설정 