### PR TITLE
🐛 fix : Slider imgs 상태관리로 처리

### DIFF
--- a/component/Slider.jsx
+++ b/component/Slider.jsx
@@ -11,16 +11,17 @@ const Slider = ({
   height = 100,
 }) => {
   const [sliderNo, setSliderNo] = useState(0);
+  const [imgsLength, setImgsLength] = useState(1);
   // Todos : setInterval로 처리 가능한 방법 이해
   // Todos : imgs가 받은게 없을 경우 1로 처리하며 1에는 사진이 없는 이미지형태 처리 필요
-  const imgsLength = useRef(imgs.length !== 0 ? imgs.length : 1);
-  const clickSlide = () => {
-    setSliderNo(sliderNo + 1);
-  };
 
-  const clickLeft = () =>
-    setSliderNo((sliderNo - 1 + imgsLength.current) % imgsLength.current);
-  const clickRight = () => setSliderNo((sliderNo + 1) % imgsLength.current);
+  useEffect(() => {
+    setImgsLength(imgs.length);
+  }, [imgs]);
+
+  const clickLeft = () => setSliderNo((sliderNo - 1 + imgsLength) % imgsLength);
+
+  const clickRight = () => setSliderNo((sliderNo + 1) % imgsLength);
 
   return (
     <SliderContainer width={width}>
@@ -33,13 +34,7 @@ const Slider = ({
       {imgs.map((img, idx) => {
         return (
           <ImgContainer width={width} height={height} key={idx}>
-            <Img
-              src={img}
-              width={width}
-              height={height}
-              sliderNo={sliderNo}
-              onClick={clickSlide}
-            />
+            <Img src={img} width={width} height={height} sliderNo={sliderNo} />
           </ImgContainer>
         );
       })}


### PR DESCRIPTION
# 기존 문제점
>Dummy-data의 경우 기존의 imgs의 길이를 가진채로 처리하여 계산에 문제가 없다. 
하지만, 비동기로 받아온 imgs의 경우 처음 아무것도 없는 imgs로 상태를 인식하여 제대로된 imgs의 길이를 처리할 수 없다. 

# 해결 방법
>useEffect를 이용하여 imgs의 변화를 감지하여 상태값으로 imgsLength를 변하게 하여 
기존의 동작을 원활히 수행시킨다. 