### PR TITLE
🐛 fix : click to mouseDown진행 및 focusOut 이벤트 실행

### DIFF
--- a/component/Input.jsx
+++ b/component/Input.jsx
@@ -32,7 +32,7 @@ const Input = ({
   // }, [searchArr]);
   // console.log(inputRef.current.style);
   const focusOut = () => {
-    // clearSearchArr();
+    clearSearchArr();
   };
 
   const clickSearch = ({ contentId, mapX, mapY }) => {
@@ -66,7 +66,7 @@ const Input = ({
                 <Li
                   key={contentId}
                   id="backgroundWhite"
-                  onClick={() => clickSearch({ contentId, mapX, mapY })}
+                  onMouseDown={() => clickSearch({ contentId, mapX, mapY })}
                   width={width}
                   height={height}
                 >


### PR DESCRIPTION
# 처음 목표

<aside>
📢 검색을 하였을 때 해당 검색부를 떠나면 
검색 내용이 지워지는 상황을 만드는 것과

검색한 검색결과를 클릭했을때 새로운 url로 넘어가는 것을 둘다하고 싶었다.

</aside>

# 시도해보기

JavaScript => React

onfocusout => onBlur

onfocusin => onFocus

<aside>
📢 각각의 이벤트를 위해 검색부가 떠나면 지워지는 onBlur 이벤트에 의해
검색부분 데이터를 `[]` 로 만들어 검색부분을 보이지 않게하고
클릭부분은 onClick이벤트에 의해 처리한다.

</aside>

## 문제점 발생

<aside>
📢 onBlur 부분은 문제가 없지만 클릭이 정상적으로 동작하지 않는다.

</aside>

## 문제점의 원인
[해결 방법](https://stackoverflow.com/questions/13980448/jquery-focusout-click-conflict)

<aside>
📢 이벤트간의 순서에 따르면 해당 이벤트들의 순서는 아래와 같다.

1. Mouse down
2. Focus out
3. Click
</aside>

즉, Focus out과 관련된 onBlur가 먼저 실행되어 click 이벤트가 정상적으로 동작할 수 없는 것이다. 

# 해결하기

<aside>
📢 해결은 이제 간단하다. click이벤트를  onBlur보다 우선순위가 높은 Mouse down으로 바꿔주면 되는 것이다.

</aside>

```jsx
<InputTag
          ref={inputRef}
          onChange={debounce}
          onBlur={focusOut}
          width={width}
          height={height}
          borderRadius={borderRadius}
          searchArr={searchArr}
          onKeyPress={checkSearchPressEnter}
        ></InputTag>
....
<Li
                  key={contentId}
                  id="backgroundWhite"
                  onMouseDown={() => clickSearch({ contentId, mapX, mapY })}
                  width={width}
                  height={height}
                >
```

<aside>
📢 onBlur와 onMouseDown으로 처리하여 정상적으로 처리되게 만들었다.

</aside>