### PR TITLE
🐛 fix : slider Image 부재에 따른 예외처리

### DIFF
--- a/component/Slider.jsx
+++ b/component/Slider.jsx
@@ -6,7 +6,7 @@ import {
 import styled from "styled-components";
 
 const Slider = ({
-  imgs = ["logo.png", "mainlogo.png", "logo.png", "mainlogo.png", "logo.png"],
+  imgs = [],
   width = 10,
 }) => {
   const [sliderNo, setSliderNo] = useState(0);

--- a/core/api/axios.js
+++ b/core/api/axios.js
@@ -5,7 +5,7 @@ const essentialParams = process.env.SERVICE_KEY;
 
 const filtering = (target) => target?.data?.response?.body?.items?.item;
 const filteringUrl = (target) =>
-  target?.data?.response?.body?.items?.item.map(({ imageUrl }) => imageUrl);
+  target?.data?.response?.body?.items?.item?.map(({ imageUrl }) => imageUrl);
 
 const getBasedList = async (pageNo = 1) => {
   const unFilteredData = await axios.get(
@@ -40,7 +40,7 @@ const getImageList = async (pageNo = 1, contentId = 3429) => {
   const unFilteredData = await axios.get(
     `/api/imageList?${essentialParams}&pageNo=${pageNo}&contentId=${contentId}`
   );
-  const filteredData = filteringUrl(unFilteredData);
+  const filteredData = filteringUrl(unFilteredData) || [];
   return filteredData;
 };
 

--- a/pages/content/[id].js
+++ b/pages/content/[id].js
@@ -35,7 +35,7 @@ const content = () => {
       <Body id="backgroundLightGray">
         <Main>
           <Title id="titleText">🏕️ {content.facltNm}</Title>
-          <Slider imgs={imageLists} width={40} />
+          {imageLists.length !== 0 && <Slider imgs={imageLists} width={40} />}
           <IntroContainer>
             <Intro introText={content.intro} />
           </IntroContainer>


### PR DESCRIPTION
# 원인
## 문제
```js
target?.data?.response?.body?.items?.item.map(({ imageUrl }) => imageUrl);
```
>해당 부분의 코드에서 item이 아예없는 경우 undefined를 map으로 접근하려하는 에러 발생

## 해결
```js
target?.data?.response?.body?.items?.item?.map(({ imageUrl }) => imageUrl);
```
>`?`를 추가하며  undefined 반환한 부분의 예외처리를 위해 `[]` 로 처리하는 하단 코드로 수정

```js
filteringUrl(unFilteredData) || [];
```