### PR TITLE
♻️ refactor : url 수정

### DIFF
--- a/component/Input.jsx
+++ b/component/Input.jsx
@@ -30,7 +30,7 @@ const Input = ({
   };
 
   const clickSearch = ({ contentId, mapX, mapY }) => {
-    router.push(`/content/${contentId}?mapX=${mapX}&mapY=${mapY}&radius=1000`);
+    router.push(`/content/${contentId}?mapX=${mapX}&mapY=${mapY}`);
   };
   return (
     <InputContainer

--- a/component/Input.jsx
+++ b/component/Input.jsx
@@ -29,9 +29,10 @@ const Input = ({
     clearSearchArr();
   };
 
-  const clickSearch = ({ contentId, mapX, mapY }) => {
-    router.push(`/content/${contentId}?mapX=${mapX}&mapY=${mapY}`);
+  const clickSearch = ({ contentId, facltNm }) => {
+    router.push(`/content/${contentId}?keyword=${facltNm}`);
   };
+
   return (
     <InputContainer
       width={width}
@@ -57,12 +58,12 @@ const Input = ({
         (searchArr.length !== 0 ? (
           <>
             <Ul width={width} height={height} borderRadius={borderRadius}>
-              {searchArr.map(({ facltNm, contentId, mapX, mapY }) => {
+              {searchArr.map(({ facltNm, contentId }) => {
                 return (
                   <Li
                     key={contentId}
                     id="backgroundWhite"
-                    onMouseDown={() => clickSearch({ contentId, mapX, mapY })}
+                    onMouseDown={() => clickSearch({ contentId, facltNm })}
                     width={width}
                     height={height}
                   >

--- a/core/api/axios.js
+++ b/core/api/axios.js
@@ -19,7 +19,7 @@ const getLocationBasedList = async (
   pageNo = 1,
   mapX = 127,
   mapY = 37,
-  radius = 10000
+  radius = 1000
 ) => {
   const unFilteredData = await axios.get(
     `/api/locationBasedList?${essentialParams}&pageNo=${pageNo}&mapX=${mapX}&mapY=${mapY}&radius=${radius}`

--- a/pages/content/[id].js
+++ b/pages/content/[id].js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/dist/client/router";
-import { getLocationBasedList, getImageList } from "../../core/api/axios";
+import { getSearchList, getImageList } from "../../core/api/axios";
 import styled from "styled-components";
 import Slider from "../../component/Slider";
 import Intro from "../../component/Intro";
@@ -15,12 +15,12 @@ const content = () => {
 
   useEffect(() => {
     if (!router.isReady) return;
-    locationBasedList(1, router.query.mapX, router.query.mapY);
+    searchList(1, router.query.keyword);
     imageList(1, router.query.id);
   }, [router.isReady]);
 
-  async function locationBasedList(pageNo = 1, mapX, mapY) {
-    const data = await getLocationBasedList(pageNo, mapX, mapY);
+  async function searchList(pageNo = 1, keyword) {
+    const data = await getSearchList(pageNo,keyword);
     setContent(data[0]);
   }
 

--- a/pages/content/[id].js
+++ b/pages/content/[id].js
@@ -20,7 +20,7 @@ const content = () => {
   }, [router.isReady]);
 
   async function locationBasedList(pageNo = 1, mapX, mapY) {
-    const data = await getLocationBasedList(pageNo, mapX, mapY, 1000);
+    const data = await getLocationBasedList(pageNo, mapX, mapY);
     setContent(data[0]);
   }
 


### PR DESCRIPTION
# 가장 이상적인 방법
`/content/785` 해당 url을 통해 contentId인 785로 API를 전달하면
관련 데이터를 받아오고 처리되는 것

# 현재 상황
해당 요청 API 전달은 존재하지않는다. 
즉, 방법은 2가지가 있다. 

## 1. url에 mapX, mapY 사용
 mapX, mapY를 전달하여 해당 반경안의 가장 가까운 캠핑장을 찾는 것이다. 
## 2.  keyword를 전달
 keyword를 전달하여 받은 첫번째 요청에 대한 캠핑장을 찾는 것이다. 

# 선택 결과
> 일단은 mapX와 mapY의 경우 자릿수가 불필요하게 많다 
만약 이를 소수점 한두자리수까지 줄인다면 자릿수가 줄어들지만 부정확한 kakaoAPI위치가 나타난다. 
결국 keyword를 활용한 방법을 이용하였다. 

url이 mapX,mapY를 사용할 때보다 훨씬 줄어 좀더 보기 좋고 직관적이다. 

`/content/3429?mapX=126.961248&mapY=35.274557` => `/content/785?keyword=더드림핑%20야영장`