### PR TITLE
🐛 fix : hover 레이아웃 충돌 수정

### DIFF
--- a/component/Camp.jsx
+++ b/component/Camp.jsx
@@ -8,6 +8,7 @@ const Camp = ({
   address = "주소",
   imgSrc = "logo.png",
   contentId,
+  isHoverActive,
   containerWidth = 223,
   containerHeight = 300,
   borderRadius = 30,
@@ -20,6 +21,7 @@ const Camp = ({
   return (
     <CampContainer
       onClick={clickCamp}
+      isHoverActive={isHoverActive}
       containerWidth={containerWidth}
       containerHeight={containerHeight}
       borderRadius={borderRadius}
@@ -52,8 +54,9 @@ const CampContainer = styled.div`
   transition: all ease 0.2s;
   box-shadow: 0px 5px 10px 0px rgba(0, 0, 0, 0.5);
   :hover {
-    transform: translateY(-5px);
-    box-shadow: 0px 10px 20px 2px rgba(0, 0, 0, 0.25);
+    transform: ${({ isHoverActive }) => isHoverActive && `translateY(-5px)`};
+    box-shadow: ${({ isHoverActive }) =>
+      isHoverActive && ` 0px 10px 20px 2px rgba(0, 0, 0, 0.25)`};
   }
 `;
 

--- a/component/CampContainer.jsx
+++ b/component/CampContainer.jsx
@@ -4,6 +4,7 @@ import Camp from "./Camp";
 
 const CampContainer = ({
   campData = [],
+  isHoverActive = true,
   containerWidth = 223,
   containerHeight = 300,
 }) => {
@@ -18,6 +19,7 @@ const CampContainer = ({
           address={addr1}
           imgSrc={returnImageSrc(firstImageUrl)}
           contentId={contentId}
+          isHoverActive={isHoverActive}
           containerWidth={containerWidth}
           containerHeight={containerHeight}
         ></Camp>

--- a/pages/index.js
+++ b/pages/index.js
@@ -160,7 +160,7 @@ export default function Home() {
               />
             )}
           </Title>
-          <CampContainer campData={campData} />
+          <CampContainer campData={campData} isHoverActive = {!isSearching}/>
           {campData.length !== 0 ? (
             <Button
               id={"backgroundLightMainColor"}


### PR DESCRIPTION
>기존 Input의 검색결과가 나타났을때의 상태에서 hover상태가 문제가 되므로
검색시에 hover 상태를 막는 역할의 props를 전달한다. 

isSearched의 부정은 isHoverActive로 처리한다.
추후 충돌 부분에 대해서도 
`isHoverActive = !(isSearched && ....)` 형태로 
확장 가능 